### PR TITLE
Additional resource guards

### DIFF
--- a/doc/doc.md
+++ b/doc/doc.md
@@ -136,7 +136,8 @@ Resource definitions can have the following fields:
 |---|---|
 | `name` | Short name for the resource. If using auto-generate then this will be the local name of the class URI and its `rdfs:label`. Also used for back references within templates. Required. |
 | `comment` | Descriptive comment, will be used as `rdfs:comment` on any auto generated class definition. |
-| `requires` | An optional dictionary mapping column names to the value required to be in that column for the resource mapping to be applied. If no value is provided, then the column is required to have any non-empty value.
+| `requires` | An optional dictionary mapping column names to the value(s) required to be in that column for the resource mapping to be applied. A list of values may be provided, in which case the column must contain at least one of the specified values. If no value is provided, then the column is required to have any non-empty value.
+| `unless` | An optional dictionary mapping column names to the value(s) required to *not* be in that column for the resource mapping to be applied. A list of values may be provided, in which case the column mus tnot contain any of the specified values.
 | `@graph` | Optional URI of a graph to which the resource template should be written. Can be a URI template. If not specified writes to the current `$graph` setting which defaults to the default graph. When using `update` format then any existing graph contents will be replaced. |
 | `@graphAdd` | As for `@graph` except that any existing graph contents will be preserved. |
 | `properties` | List of property/value templates defining the properties to attach to the generated resource |

--- a/src/rdf_mapper/lib/mapper_spec.py
+++ b/src/rdf_mapper/lib/mapper_spec.py
@@ -203,6 +203,7 @@ class ResourceSpec:
             self.preserved_graph = "@graphAdd" in spec
             self.properties = _listify(props)
             self.requires = spec.get("requires")
+            self.unless = spec.get("unless")
             if self.requires is not None and not isinstance(self.requires, dict):
                 _error(f"Resource spec requires must be a dictionary, was {self.requires}")
         else:

--- a/src/rdf_mapper/lib/template_support.py
+++ b/src/rdf_mapper/lib/template_support.py
@@ -225,12 +225,34 @@ def process_resource_spec(name: str, rs: ResourceSpec, state: TemplateState) -> 
             value = state.get(key)
             expected = rs.requires.get(key)
             if expected is not None:
+                if type(expected) is list:
+                    if value not in expected:
+                        logging.warning(
+                            f"Skipping resource {rs.name} on row {state.get('$row')} because value for {key} is {value}, which is not one of the required values {expected}.")  # noqa: E501
+                        return None
                 if value != expected:
                     logging.warning(
                         f"Skipping resource {rs.name} on row {state.get('$row')} because value for {key} is {value}, which is different from the required value {expected}.")  # noqa: E501
                     return None
             elif not value:
                 logging.warning(f"Skipping resource {rs.name} on row {state.get('$row')} because value for {key} is empty.")
+                return None
+
+    # If the resource spec has an unless dict, check the row for non-matching values
+    if rs.unless:
+        for key in rs.unless:
+            value = state.get(key)
+            unless_value = rs.unless.get(key)
+            if type(unless_value) is list:
+                if value in unless_value:
+                    logging.warning(
+                        f"Skipping resource {rs.name} on row {state.get('$row')} because value for {key}  ({value}) is one of the filtered values {unless_value}."
+                    )
+                    return None
+            if value == unless_value:
+                logging.warning(
+                    f"Skipping resource {rs.name} on row {state.get('$row')} because value for {key} is {value}."
+                )
                 return None
 
     # Check for switch of graph

--- a/src/rdf_mapper/lib/template_support.py
+++ b/src/rdf_mapper/lib/template_support.py
@@ -230,7 +230,7 @@ def process_resource_spec(name: str, rs: ResourceSpec, state: TemplateState) -> 
                         logging.warning(
                             f"Skipping resource {rs.name} on row {state.get('$row')} because value for {key} is {value}, which is not one of the required values {expected}.")  # noqa: E501
                         return None
-                if value != expected:
+                elif value != expected:
                     logging.warning(
                         f"Skipping resource {rs.name} on row {state.get('$row')} because value for {key} is {value}, which is different from the required value {expected}.")  # noqa: E501
                     return None
@@ -249,7 +249,7 @@ def process_resource_spec(name: str, rs: ResourceSpec, state: TemplateState) -> 
                         f"Skipping resource {rs.name} on row {state.get('$row')} because value for {key}  ({value}) is one of the filtered values {unless_value}."
                     )
                     return None
-            if value == unless_value:
+            elif value == unless_value:
                 logging.warning(
                     f"Skipping resource {rs.name} on row {state.get('$row')} because value for {key} is {value}."
                 )

--- a/test/expected/required_filter.ttl
+++ b/test/expected/required_filter.ttl
@@ -1,0 +1,3 @@
+
+<http://example.com/123> a <http://example.com/File> .
+

--- a/test/expected/unless_filter.ttl
+++ b/test/expected/unless_filter.ttl
@@ -1,0 +1,3 @@
+
+<http://example.com/456> a <http://example.com/File> .
+

--- a/test/test_template_processor.py
+++ b/test/test_template_processor.py
@@ -232,6 +232,67 @@ class TestTemplateProcessor(unittest.TestCase):
             }, auto_declare=False),
             [self.row1], "map_by.ttl" )
 
+    def test_required_filter(self) -> None:
+        self.do_test(
+            MapperSpec({
+                "resources": [{
+                    "name": "Test",
+                    "requires": { "id": "123" },
+                    "properties": {
+                        "@id" : "<http://example.com/{id}>",
+                        "@type" : "<http://example.com/File>",
+                    }
+                }]
+            }, auto_declare=False),
+            [self.row1, self.row2], "required_filter.ttl"
+        )
+
+    def test_required_in_filter(self) -> None:
+        self.do_test(
+        MapperSpec({
+            "resources": [{
+                "name": "Test",
+                "requires": {"id": ["123", "789"]},
+                "properties": {
+                    "@id": "<http://example.com/{id}>",
+                    "@type": "<http://example.com/File>",
+                }
+            }]
+        }, auto_declare=False),
+        [self.row1, self.row2],
+        "required_filter.ttl"
+        )
+
+    def test_unless_filter(self) -> None:
+        self.do_test(
+            MapperSpec({
+                "resources": [{
+                    "name": "Test",
+                    "unless": { "id": "123" },
+                    "properties": {
+                        "@id" : "<http://example.com/{id}>",
+                        "@type" : "<http://example.com/File>",
+                    }
+                }]
+            }, auto_declare=False),
+            [self.row1, self.row2], "unless_filter.ttl"
+        )
+
+    def test_unless_in_filter(self) -> None:
+        self.do_test(
+            MapperSpec({
+                "resources": [{
+                    "name": "Test",
+                    "unless": { "id": ["123", "789"]},
+                    "properties": {
+                        "@id" : "<http://example.com/{id}>",
+                        "@type" : "<http://example.com/File>",
+                    }
+                }]
+            }, auto_declare=False),
+            [self.row1, self.row2, self.row3], "unless_filter.ttl"
+        )
+
 
     def do_test(self, spec: MapperSpec, rows: list, expected: str | None) -> None:
         self.maxDiff = 5000


### PR DESCRIPTION
* Allow a list of values in the `requires` guard. Column must match one of the values for the guard to be passed.
* Add a `unless` guard to act as the inverse of `requires`. Also allows either a single value or a list of values. The column must not contain any of the listed values to pass the guard.