### PR TITLE
Repro and fix for #22

### DIFF
--- a/src/rdf_mapper/lib/template_support.py
+++ b/src/rdf_mapper/lib/template_support.py
@@ -305,7 +305,10 @@ def process_property_value(resource: IdentifiedNode, prop: str, template: Any, s
     if isinstance(template, list):
         # Multiple expansions defined for this property
         for template_item in template:
-            process_property_value(resource, prop, template_item, state)
+            try:
+                process_property_value(resource, prop, template_item, state)
+            except ValueError as ex:
+                logging.warning(f"Skipping {prop} on row {state.get('$row')} because {ex}")
         return
 
     # Check for inverse property

--- a/test/expected/skip_missing_in_list.ttl
+++ b/test/expected/skip_missing_in_list.ttl
@@ -1,0 +1,6 @@
+@prefix def: <https://epimorphics.com/library/def/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<http://example.com/1> a skos:Concept ;
+    def:missing "123" .
+

--- a/test/test_template_processor.py
+++ b/test/test_template_processor.py
@@ -71,6 +71,22 @@ class TestTemplateProcessor(unittest.TestCase):
             }),
             [self.row1], "skip_missing.ttl")
 
+    def test_skip_missing_in_list(self) -> None:
+        self.do_test(
+             MapperSpec({
+                "globals": {"$datasetID": "testds"},
+                "namespaces" : { "def" : "https://epimorphics.com/library/def/" },
+                "resources" : [{
+                    "name": "registration",
+                    "properties": {
+                        "@id" : "<http://example.com/{$row}>",
+                        "@type" : "<skos:Concept>",
+                        "<def:missing>" : ["{missing}", "{id}"]
+                    }
+                }]
+            }),
+            [self.row1], "skip_missing_in_list.ttl")
+
     def test_inverse_prop(self) -> None:
         self.do_test(
              MapperSpec({


### PR DESCRIPTION
When processing a list of property values, if processing one of them raises a ValueError, log the error and continue processing the rest.