### PR TITLE
Fix the way registered functions with arguments are invoked

### DIFF
--- a/src/rdf_mapper/lib/template_support.py
+++ b/src/rdf_mapper/lib/template_support.py
@@ -420,7 +420,12 @@ def find_fn(call: str) -> Callable | None:
                         bindings.append(f"state.get('{arg}') or {arg}")
                     else:
                         bindings.append(arg)
-            dfn = f"lambda value, state: {fnname}(value, state, {','.join(bindings)})"
+            if fnname in _FUN_REGISTRY:
+                # When the function is in the registry it needs to be invoked using the __call__ method
+                dfn = f"lambda value, state: _FUN_REGISTRY['{fnname}'].__call__(value, state, {', '.join(bindings)})"
+            else:
+                # Global functions can be invoked directly
+                dfn = f"lambda value, state: {fnname}(value, state, {','.join(bindings)})"
             fn = eval(dfn)
             # print(f"Registering {dfn}")
             register_fn(call, fn)


### PR DESCRIPTION
When the function to be invoked is in the function registry, use the `__call__()` method on the registered function rather than trying to invoke it directly. Invoking directly results in a NameError from Python as the function is not in the global scope.