### PR TITLE
Update requires check to test for either None or an empty string

### DIFF
--- a/src/rdf_mapper/lib/template_support.py
+++ b/src/rdf_mapper/lib/template_support.py
@@ -234,9 +234,11 @@ def process_resource_spec(name: str, rs: ResourceSpec, state: TemplateState) -> 
                     logging.warning(
                         f"Skipping resource {rs.name} on row {state.get('$row')} because value for {key} is {value}, which is different from the required value {expected}.")  # noqa: E501
                     return None
-            elif not value:
-                logging.warning(f"Skipping resource {rs.name} on row {state.get('$row')} because value for {key} is empty.")
+            elif value is None:
+                logging.warning(f"Skipping resource {rs.name} on row {state.get('$row')} because there is no value for {key}.")
                 return None
+            elif value == '':
+                logging.warning(f"Skipping resource {rs.name} on row {state.get('$row')} because value for {key} is an empty string.")
 
     # If the resource spec has an unless dict, check the row for non-matching values
     if rs.unless:


### PR DESCRIPTION
This fixes an issue where if the value being tested is an array, the conversion to a boolean would fail. The change means that any array or object (even empty ones) will pass a requires check.