### PR TITLE
Fix literal with datatype expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ hse-out.ttl
 dist
 build
 .vscode
+.coverage

--- a/src/rdf_mapper/lib/pattern.py
+++ b/src/rdf_mapper/lib/pattern.py
@@ -21,9 +21,6 @@ class Pattern:
     _PIPEPATTERN = re.compile(r"\s*\|\s*")
 
     def __init__(self, pattern: str):
-        self.type = "plain"
-        self.lang = None
-        self.datatype = None
         self._patternString = pattern
         self._call_chain: list[Callable[[Identifier|None, TemplateState], Iterator[Identifier]]] = []
         self._parsePattern()
@@ -55,25 +52,7 @@ class Pattern:
 
     def _parsePattern(self):
         to_parse = self._patternString
-        # to_parse = self._parse_langstring(to_parse)
-        # to_parse = self._parse_datatype(to_parse)
         self._parse_variables_and_statics(to_parse)
-    
-    def _parse_langstring(self, to_parse: str) -> str:
-        langstring_match = self._LANGSTRING_PATTERN.match(to_parse)
-        if langstring_match:
-            self.type = "langstring"
-            self.lang = langstring_match.group(2)
-            return langstring_match.group(1)
-        return to_parse
-        
-    def _parse_datatype(self, to_parse: str) -> str:
-        dt_match = self._DT_PATTERN.match(to_parse)
-        if dt_match:
-            self.type = "datatype"
-            self.datatype = dt_match.group(2)
-            return dt_match.group(1)
-        return to_parse
     
     def _parse_variables_and_statics(self, to_parse: str):
         last_index = 0

--- a/src/rdf_mapper/lib/pattern.py
+++ b/src/rdf_mapper/lib/pattern.py
@@ -16,7 +16,7 @@ class PipelineFunction(Protocol):
 class Pattern:
     
     _LANGSTRING_PATTERN = re.compile(r"^(.+)@([\w\-]+)$", re.DOTALL)
-    _DT_PATTERN = re.compile(r"^(.+)\^\^(<[^>]+>)$", re.DOTALL)
+    _DT_PATTERN = re.compile(r"^(.+)\^\^<([^>]+)>$", re.DOTALL)
     _VARPATTERN = re.compile(r"{([^}]*)}")
     _PIPEPATTERN = re.compile(r"\s*\|\s*")
 
@@ -35,11 +35,7 @@ class Pattern:
         yield from map(lambda v: self._wrap_literal(v), filter(lambda v: v is not None, values))
 
     def _wrap_literal(self, node: Identifier) -> Identifier:
-        if self.type == "langstring":
-            return Literal(str(node), lang=self.lang)
-        elif self.type == "datatype":
-            return Literal(str(node), datatype=self.datatype)
-        elif isinstance(node, Literal) and isinstance(node.value, str):
+        if isinstance(node, Literal) and isinstance(node.value, str):
             # Attempt to parse language tagged string or datatype from the literal value if it is in the form "value@lang" or "value^^datatype"
             langstring_match = self._LANGSTRING_PATTERN.match(node.value)
             if langstring_match:
@@ -59,8 +55,8 @@ class Pattern:
 
     def _parsePattern(self):
         to_parse = self._patternString
-        to_parse = self._parse_langstring(to_parse)
-        to_parse = self._parse_datatype(to_parse)
+        # to_parse = self._parse_langstring(to_parse)
+        # to_parse = self._parse_datatype(to_parse)
         self._parse_variables_and_statics(to_parse)
     
     def _parse_langstring(self, to_parse: str) -> str:

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -9,15 +9,17 @@ from rdf_mapper.lib.template_state import TemplateState
 class TestPattern (unittest.TestCase):
     def test_langstring(self):
         pattern = Pattern("Hello@en")
-        self.assertEqual(pattern.type, "langstring")
-        self.assertEqual(pattern.lang, "en")
-        self.assertEqual(pattern.datatype, None)
+        # self.assertEqual(pattern.type, "langstring")
+        # self.assertEqual(pattern.lang, "en")
+        # self.assertEqual(pattern.datatype, None)
+        self.assertEqual(list(pattern.execute(TemplateState(ChainMap(), Dataset(), MapperSpec()))), [Literal("Hello", lang="en")])
     
     def test_datatype(self):
         pattern = Pattern("42^^<http://www.w3.org/2001/XMLSchema#integer>")
-        self.assertEqual(pattern.type, "datatype")
-        self.assertEqual(pattern.lang, None)
-        self.assertEqual(pattern.datatype, "<http://www.w3.org/2001/XMLSchema#integer>")
+        # self.assertEqual(pattern.type, "datatype")
+        # self.assertEqual(pattern.lang, None)
+        # self.assertEqual(pattern.datatype, "<http://www.w3.org/2001/XMLSchema#integer>")
+        self.assertEqual(list(pattern.execute(TemplateState(ChainMap(), Dataset(), MapperSpec()))), [Literal("42", datatype="http://www.w3.org/2001/XMLSchema#integer")])
     
     def test_variables_and_statics(self):
         pattern = Pattern("Hello {name}!")
@@ -28,6 +30,15 @@ class TestPattern (unittest.TestCase):
         state = TemplateState(
             ChainMap({"name": "Alice"}), Dataset(), MapperSpec())
         self.assertEqual(list(pattern.execute(state)), [Literal("Hello Alice!")])
+    
+    def test_datatype_as_variable(self):
+        pattern = Pattern("{@value}^^<{@type}>")
+        # self.assertEqual(pattern.type, "datatype")
+        state = TemplateState(
+            ChainMap({"@value": "42", "@type": "http://www.w3.org/2001/XMLSchema#integer"}), Dataset(), MapperSpec())
+        actual = list(pattern.execute(state))
+        print(actual)
+        self.assertEqual(actual, [Literal("42", datatype="http://www.w3.org/2001/XMLSchema#integer")])
     
     def test_variable_function_chain(self):
         pattern = Pattern("{greeting} {name | toUpper}!")


### PR DESCRIPTION
Fixes #51 by processing the language tag and datatype suffixes *after* expansion processing rather than before and after. This also simplifies the Pattern class allowing some redundant code to be removed.