### PR TITLE
Repro and fix for #65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 This project is currently in pre-release and a new minor version increment MAY NOT be backwards compatible with the previous minor version. Breaking changes are marked as BREAKING in the descriptions below.
 
+## Unreleased
+
+### Fixed
+
+- Fixed issue where a property mapping like "{foo}" would generate a single literal value like "['A', 'B' 'C']" if the value of `foo` was an array. The mapper now correctly returns a separate literal value for each item in the array.
+
 ## [0.3.1]
 
 ### Fixed

--- a/src/rdf_mapper/lib/pattern.py
+++ b/src/rdf_mapper/lib/pattern.py
@@ -117,8 +117,16 @@ class VariableExpansion:
                 else:
                     results.append(result)
             values = results
-        yield from map(lambda v: Literal(v) if not isinstance(v, Identifier) else v, filter(lambda v: v is not None, values))
+        yield from self._wrap_results(values)
 
+        # yield from map(lambda v: Literal(v) if not isinstance(v, Identifier) else v, filter(lambda v: v is not None, values))
+
+    def _wrap_results(self, values: list[Any]) -> Iterator[Identifier]:
+        for v in values:
+            if isinstance(v, Iterable) and not isinstance(v, str):
+                yield from self._wrap_results(list(v))
+            elif v is not None:
+                yield Literal(v) if not isinstance(v, Identifier) else v
 
 def static_value(value: str) -> Callable[[Identifier|None, TemplateState], Iterator[Literal]]:
     def _static_value(_: Identifier|None, __: TemplateState) -> Iterator[Literal]:
@@ -127,10 +135,10 @@ def static_value(value: str) -> Callable[[Identifier|None, TemplateState], Itera
 
 
 def _variable_value(var_name: str) -> Callable[[Identifier|None, TemplateState], Iterator[Any]]:
-    def _variable_value(_: Identifier|None, state: TemplateState) -> Iterator[Any]:
+    def _variable_value_(_: Identifier|None, state: TemplateState) -> Iterator[Any]:
         if var_name in state.context:
             yield state.context[var_name]
         else:
             raise MissingValueWarning(f"Variable '{var_name}' not found in context")
-    return _variable_value
+    return _variable_value_
 

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -1,28 +1,30 @@
-from collections import ChainMap
 import unittest
+from collections import ChainMap
 
 from rdflib import Dataset, Literal
+
 from rdf_mapper.lib.mapper_spec import MapperModel, MapperSpec
 from rdf_mapper.lib.pattern import Pattern
 from rdf_mapper.lib.template_state import TemplateState
 
+
 class TestPattern (unittest.TestCase):
 
-    def test_langstring(self):
+    def test_langstring(self) -> None:
         pattern = Pattern("Hello@en")
         # self.assertEqual(pattern.type, "langstring")
         # self.assertEqual(pattern.lang, "en")
         # self.assertEqual(pattern.datatype, None)
         self.assertEqual(list(pattern.execute(TemplateState(ChainMap(), Dataset(), MapperSpec()))), [Literal("Hello", lang="en")])
 
-    def test_datatype(self):
+    def test_datatype(self) -> None:
         pattern = Pattern("42^^<http://www.w3.org/2001/XMLSchema#integer>")
         # self.assertEqual(pattern.type, "datatype")
         # self.assertEqual(pattern.lang, None)
         # self.assertEqual(pattern.datatype, "<http://www.w3.org/2001/XMLSchema#integer>")
         self.assertEqual(list(pattern.execute(TemplateState(ChainMap(), Dataset(), MapperSpec()))), [Literal("42", datatype="http://www.w3.org/2001/XMLSchema#integer")])
 
-    def test_variables_and_statics(self):
+    def test_variables_and_statics(self) -> None:
         pattern = Pattern("Hello {name}!")
         self.assertEqual(len(pattern._call_chain), 3)  # static "Hello ", variable "name", static "!"
         self.assertTrue(callable(pattern._call_chain[0]))  # static "Hello "
@@ -32,7 +34,19 @@ class TestPattern (unittest.TestCase):
             ChainMap({"name": "Alice"}), Dataset(), MapperSpec())
         self.assertEqual(list(pattern.execute(state)), [Literal("Hello Alice!")])
 
-    def test_datatype_as_variable(self):
+    def test_variable_with_list_value(self) -> None:
+        pattern = Pattern("{names}")
+        state = TemplateState(
+            ChainMap({"names": ["Alice", "Bob", "Charlie"]}), Dataset(), MapperSpec())
+        self.assertEqual(list(pattern.execute(state)), [Literal("Alice"), Literal("Bob"), Literal("Charlie")])
+
+    def test_variable_with_static_and_list_value(self) -> None:
+        pattern = Pattern("Name: {names}")
+        state = TemplateState(
+            ChainMap({"names": ["Alice", "Bob", "Charlie"]}), Dataset(), MapperSpec())
+        self.assertEqual(list(pattern.execute(state)), [Literal("Name: Alice"), Literal("Name: Bob"), Literal("Name: Charlie")])
+
+    def test_datatype_as_variable(self) -> None:
         pattern = Pattern("{@value}^^<{@type}>")
         # self.assertEqual(pattern.type, "datatype")
         state = TemplateState(
@@ -41,14 +55,14 @@ class TestPattern (unittest.TestCase):
         print(actual)
         self.assertEqual(actual, [Literal("42", datatype="http://www.w3.org/2001/XMLSchema#integer")])
 
-    def test_variable_function_chain(self):
+    def test_variable_function_chain(self) -> None:
         pattern = Pattern("{greeting} {name | toUpper}!")
         self.assertEqual(len(pattern._call_chain), 4)  # variable "greeting", static " ", variable "name", static "!"
         state = TemplateState(
             ChainMap({"greeting": "Hi", "name": "Bob"}), Dataset(), MapperSpec())
         self.assertEqual(list(pattern.execute(state)), [Literal("Hi BOB!")])
 
-    def test_function_chain_with_split(self):
+    def test_function_chain_with_split(self) -> None:
         pattern = Pattern("{names | splitComma | toUpper}")
         state = TemplateState(
             ChainMap({"names": "Alice,Bob,Charlie"}), Dataset(), MapperSpec())


### PR DESCRIPTION
Add tests that reproduce the issue reported on #65 
When the result of a variable expansion is a list, yield each element of the list rather than the list as a single element.
Fixes #65