### PR TITLE
Empty value handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 This project is currently in pre-release and a new minor version increment MAY NOT be backwards compatible with the previous minor version. Breaking changes are marked as BREAKING in the descriptions below.
 
+## Unreleased
+
+### Fixed
+
+- Fixed an issue where the handling of missing/empty string values in 0.3.x differed to the handling in 0.2.x. When a missing/empty string/None value is encountered while expanding a property template, no value will be emitted even if the template contains static strings or other variables that expand to non-empty values. (#68)
+
 ## [0.3.2] - 2026-04-30
 
 ### Fixed

--- a/src/rdf_mapper/lib/pattern.py
+++ b/src/rdf_mapper/lib/pattern.py
@@ -1,11 +1,10 @@
 import re
-from typing import Any, Callable, Iterable, Iterator, Mapping, Protocol
+from typing import Any, Callable, Iterable, Iterator, List, Mapping, Protocol
 
 from rdflib import Literal
 from rdflib.term import Identifier
 
 from rdf_mapper.lib import function
-from rdf_mapper.lib.errors import MissingValueWarning
 from rdf_mapper.lib.template_state import TemplateState
 
 _CURI_PATTERN = re.compile(r"([_A-Za-z][\w\-\.]*):([\w\-\.]+)")
@@ -18,10 +17,11 @@ def _expand_curi(uriref: str, namespaces: Mapping[str,str]) -> str:
             return ns + match.group(2)
     return uriref
 
+def _is_none_or_empty(value: Any) -> bool:
+    return value is None or (isinstance(value, str) and value == "")
 
-class PipelineFunction(Protocol):
-    def __call__(self, lit: Literal|None, *args: str) -> Literal:
-        ...
+def _is_iterable(value: Any) -> bool:
+    return isinstance(value, Iterable) and not isinstance(value, str)
 
 class Pattern:
 
@@ -40,11 +40,11 @@ class Pattern:
         self._call_chain: list[Callable[[Identifier|None, TemplateState], Iterator[Identifier]]] = []
         self._parsePattern()
 
-    def execute(self, state: TemplateState) -> Iterator[Identifier]:
+    def execute(self, state: TemplateState) -> List[Identifier]:
         values = list(self._call_chain[0](None, state))
         for func in self._call_chain[1:]:
             values = list(self._concat(v, result) for v in values for result in func(v, state))
-        yield from filter(lambda v: v is not None, map(lambda v: self._wrap_literal(v, state.spec.namespaces), values)) #type: ignore
+        return list(filter(lambda v: v is not None, map(lambda v: self._wrap_literal(v, state.spec.namespaces), values))) #type: ignore
 
     def _wrap_literal(self, node: Identifier|None, namespaces: Mapping[str, str]) -> Identifier|None:
         if node is None:
@@ -104,7 +104,7 @@ class VariableExpansion:
 
     def execute(self,_:Any, state: TemplateState) -> Iterator[Identifier]:
         values = self._call_chain[0](None, state)
-        if isinstance(values, Iterable) and not isinstance(values, str):
+        if _is_iterable(values):
             values = list(values)
         else:
             values = [values]
@@ -112,20 +112,18 @@ class VariableExpansion:
             results = []
             for v in values:
                 result = func(v, state)
-                if isinstance(result, Iterable) and not isinstance(result, str):
+                if _is_iterable(result):
                     results.extend(result)
                 else:
                     results.append(result)
             values = results
         yield from self._wrap_results(values)
 
-        # yield from map(lambda v: Literal(v) if not isinstance(v, Identifier) else v, filter(lambda v: v is not None, values))
-
     def _wrap_results(self, values: list[Any]) -> Iterator[Identifier]:
         for v in values:
-            if isinstance(v, Iterable) and not isinstance(v, str):
+            if _is_iterable(v):
                 yield from self._wrap_results(list(v))
-            elif v is not None:
+            elif not _is_none_or_empty(v):
                 yield Literal(v) if not isinstance(v, Identifier) else v
 
 def static_value(value: str) -> Callable[[Identifier|None, TemplateState], Iterator[Literal]]:
@@ -133,12 +131,9 @@ def static_value(value: str) -> Callable[[Identifier|None, TemplateState], Itera
         yield Literal(value)
     return _static_value
 
-
 def _variable_value(var_name: str) -> Callable[[Identifier|None, TemplateState], Iterator[Any]]:
     def _variable_value_(_: Identifier|None, state: TemplateState) -> Iterator[Any]:
-        if var_name in state.context:
+        if var_name in state.context and not _is_none_or_empty(state.context[var_name]):
             yield state.context[var_name]
-        else:
-            raise MissingValueWarning(f"Variable '{var_name}' not found in context")
     return _variable_value_
 

--- a/src/rdf_mapper/lib/template_support.py
+++ b/src/rdf_mapper/lib/template_support.py
@@ -334,16 +334,17 @@ def process_property_value(resource: IdentifiedNode, prop: str, template: Any, s
 
     if isinstance(template, list):
         # Multiple expansions defined for this property
-        for template_item in template:
+        has_values = False
+        for template_ix, template_item in enumerate(template):
             try:
                 process_property_value(resource, prop, template_item, state)
-            except MissingValueWarning as warn:
-                logging.warning(f"Skipping {prop} on row {state.get('$row')}: {warn}")
+                has_values = True
+            except MissingValueWarning:
+                pass
             except ValueError as ex:
-                if state.abort_on_error:
-                    raise ValueError(f"Failed to process property {prop} on row {state.get('$row')}: {ex}") from ex
-                else:
-                    logging.warning(f"Skipping {prop} on row {state.get('$row')} because {ex}")
+                logging.warning(f"Skipping template {template_ix} for property {prop} on row {state.get('$row')} because {ex}")
+        if not has_values and state.abort_on_error:
+            raise ValueError(f"No templates for property {prop} on row {state.get('$row')} produced any values")
         return
 
     # Check for inverse property
@@ -382,6 +383,11 @@ def process_property_value(resource: IdentifiedNode, prop: str, template: Any, s
         raise NotImplementedError("Implement inline property specs")
 
     if isinstance(value, list):
+        if len(value) == 0:
+            if prop_spec and prop_spec.required:
+                raise ValueError(f"No values produced for property {prop} with template {template}")
+            else:
+                raise MissingValueWarning(f"No values produced for property {prop} with template {template}")
         for v in value:
             state.add_to_graph((v, propref, resource) if inverse else (resource, propref, v))
     else:
@@ -393,7 +399,8 @@ def process_property_value(resource: IdentifiedNode, prop: str, template: Any, s
             state.add_to_graph(triple)
         elif prop_spec and  prop_spec.required:
             raise ValueError(f"Value missing for required property {prop_spec.name}, pattern: {template}")
-        # else do nothing, missing value but not required
+        else:
+            raise MissingValueWarning(f"Value missing for property {prop}, pattern: {template}")
 
 _AUTO_CLASS_SPEC = ResourceSpec(ResourceModel(
     name="AUTO_CLASS",

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -19,10 +19,27 @@ class TestPattern (unittest.TestCase):
 
     def test_datatype(self) -> None:
         pattern = Pattern("42^^<http://www.w3.org/2001/XMLSchema#integer>")
-        # self.assertEqual(pattern.type, "datatype")
-        # self.assertEqual(pattern.lang, None)
-        # self.assertEqual(pattern.datatype, "<http://www.w3.org/2001/XMLSchema#integer>")
         self.assertEqual(list(pattern.execute(TemplateState(ChainMap(), Dataset(), MapperSpec()))), [Literal("42", datatype="http://www.w3.org/2001/XMLSchema#integer")])
+
+    def test_simple_variable(self) -> None:
+        pattern = Pattern("{name}")
+        self.assertEqual(len(pattern._call_chain), 1)  # variable "name"
+        self.assertTrue(callable(pattern._call_chain[0]))  # variable "name"
+        state = TemplateState(
+            ChainMap({"name": "Alice"}), Dataset(), MapperSpec())
+        self.assertEqual(list(pattern.execute(state)), [Literal("Alice")])
+        state = TemplateState(
+            ChainMap({"name": ["Alice", "Bob", "Charlie"]}), Dataset(), MapperSpec())
+        self.assertEqual(list(pattern.execute(state)), [Literal("Alice"), Literal("Bob"), Literal("Charlie")])
+        state = TemplateState(
+            ChainMap({}), Dataset(), MapperSpec())
+        self.assertEqual(list(pattern.execute(state)), [])  # Missing variable should not be yielded as literals
+        state = TemplateState(
+            ChainMap({"name": None}), Dataset(), MapperSpec())
+        self.assertEqual(list(pattern.execute(state)), [])  # None values should not be yielded as literals
+        state = TemplateState(
+            ChainMap({"name": ""}), Dataset(), MapperSpec())
+        self.assertEqual(list(pattern.execute(state)), [])  # Empty string values should not be yielded as literals
 
     def test_variables_and_statics(self) -> None:
         pattern = Pattern("Hello {name}!")
@@ -33,18 +50,22 @@ class TestPattern (unittest.TestCase):
         state = TemplateState(
             ChainMap({"name": "Alice"}), Dataset(), MapperSpec())
         self.assertEqual(list(pattern.execute(state)), [Literal("Hello Alice!")])
-
-    def test_variable_with_list_value(self) -> None:
-        pattern = Pattern("{names}")
         state = TemplateState(
-            ChainMap({"names": ["Alice", "Bob", "Charlie"]}), Dataset(), MapperSpec())
-        self.assertEqual(list(pattern.execute(state)), [Literal("Alice"), Literal("Bob"), Literal("Charlie")])
-
-    def test_variable_with_static_and_list_value(self) -> None:
-        pattern = Pattern("Name: {names}")
+            ChainMap({}), Dataset(), MapperSpec())
+        self.assertEqual(list(pattern.execute(state)), [])  # Missing variable should not be yielded as literals
         state = TemplateState(
-            ChainMap({"names": ["Alice", "Bob", "Charlie"]}), Dataset(), MapperSpec())
-        self.assertEqual(list(pattern.execute(state)), [Literal("Name: Alice"), Literal("Name: Bob"), Literal("Name: Charlie")])
+            ChainMap({"name": None}), Dataset(), MapperSpec())
+        self.assertEqual(list(pattern.execute(state)), [])  # None values should not be yielded as literals
+        state = TemplateState(
+            ChainMap({"name": ""}), Dataset(), MapperSpec())
+        self.assertEqual(list(pattern.execute(state)), [])  # Empty string values should not be yielded as literals
+        state = TemplateState(
+            ChainMap({"name": ["Alice", "Bob", "Charlie"]}), Dataset(), MapperSpec())
+        self.assertEqual(list(pattern.execute(state)),
+                         [Literal("Hello Alice!"), Literal("Hello Bob!"), Literal("Hello Charlie!")])
+        state = TemplateState(
+            ChainMap({"name": ["Alice", "", "Charlie"]}), Dataset(), MapperSpec())
+        self.assertEqual(list(pattern.execute(state)), [Literal("Hello Alice!"), Literal("Hello Charlie!")])
 
     def test_datatype_as_variable(self) -> None:
         pattern = Pattern("{@value}^^<{@type}>")


### PR DESCRIPTION
* When a variable expansion in a property template produces a result of None or an empty string, or if the referenced variable does not exist, yield None rather than a partially expanded template.
* Improve the handling of lists of property values and the handling of lists of templates so that a ValueError for a missing value on a required property is raised only if all of the property templates for that property produce no value rather than if any one of them produces no value.