### PR TITLE
Add support for passing globals on the command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project is currently in pre-release and a new minor version increment MAY N
 
 ## Unreleased
 
+### New
+
+- Added support for defining global variable values on the command-line with the `-g`/`--set-global` option.
+
 ### Fixed
 
 - Fixed an issue where the handling of missing/empty string values in 0.3.x differed to the handling in 0.2.x. When a missing/empty string/None value is encountered while expanding a property template, no value will be emitted even if the template contains static strings or other variables that expand to non-empty values. (#68)

--- a/doc/doc.md
+++ b/doc/doc.md
@@ -7,7 +7,7 @@ Maps are expressed in (largely) declarative yaml and the mapper tool will proces
 Operation:
 
 ```sh
-    mapper [--auto-declare] [--format=turtle] [--abort-on-error] template input [output]
+    mapper [--auto-declare] [--format=turtle] [--abort-on-error] [-g/--set-global KEY=VALUE] template input [output]
 ```
 
 Formats supported are `turtle` (default), `trig`, `nquads`, `update` and `delete`. 
@@ -26,6 +26,9 @@ If no output file is specified the transformed data will be written to stdout.
 With the `--abort-on-error` flag set, any errors that occur will prevent output being generated but the mapper will still process the whole input (so as to find all errors) then exit with an error status.
 
 Errors and warnings will be logged to stderr and to `mapper.log`.
+
+The `-g` or `--set-global` option can be used to define the value for a global variable. Values defined in this way will override any existing value in the processed template.
+Multiple variables can be defined by repeating the `-g`/`--set-global` option for each variable.
 
 Key features:
 
@@ -108,7 +111,7 @@ resources:
 
 The short name for the dataset is set by binding `$datasetID` in the first stanza. Variables use a convention of a `$` prefix for builtin or global configuration values.
 
-If run with `--auto-declare` then each row of the source data will generate a resource of type `def:HSERegistration` with two properties, derived from the columns `Product Name` and `MAPP (Reg.) Number` in the source data.  The output will also include a minimal class definition for `def:HSERegistration` and for the two properties. The resources themselves will be generated in a `data:` namespace. The `def:` and `data:` namespaces default to be relative to a dataset namespace which in turn uses the `$datasetID` combined with a default global base namespace. 
+If run with `--auto-declare` then each row of the source data will generate a resource of type `def:HSERegistration` with two properties, derived from the columns `Product Name` and `MAPP (Reg.) Number` in the source data.  The output will also include a minimal class definition for `def:HSERegistration` and for the two properties. The resources themselves will be generated in a `data:` namespace. The `def:` and `data:` namespaces default to be relative to a dataset namespace which in turn uses the `$datasetID` combined with a default global base namespace.
 
 ## Map file Structure
 

--- a/src/rdf_mapper/mapper.py
+++ b/src/rdf_mapper/mapper.py
@@ -48,10 +48,20 @@ argparser.add_argument('--format', choices=['turtle', 'nquads', 'trig', 'update'
                         help='Output format: nquads, trig, update, or delete')
 argparser.add_argument('--abort-on-error', action='store_true',
                        help='Abort processing if an error was encountered, but process all rows to collect errors first')
+argparser.add_argument('-g', '--set-global', action='append', type=str,
+                       metavar="KEY=VALUE",
+                       help='Set a global variable for use in the template.')
 
 def main() -> None:
     args = argparser.parse_args()
     spec = load_template(args.template[0])
+
+    if args.set_global:
+        print (f"Setting global variables: {args.set_global}")
+        for item in args.set_global:
+            key, value = item.split("=", 1)
+            spec.globals[key] = value
+
     spec.auto_declare = args.auto_declare
     datafile = args.datafile[0]
 


### PR DESCRIPTION
Implements #70 

I opted for the simple approach where there is no checking of the variables you define on the command line, so it is possible both to override existing globals and to add new globals into the context.