### PR TITLE
Do not generate URI when a URI template produces no values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 This project is currently in pre-release and a new minor version increment MAY NOT be backwards compatible with the previous minor version. Breaking changes are marked as BREAKING in the descriptions below.
 
+## Unreleased
+
+## Changed
+
+- Changed the handling of property value templates that generate a URI (i.e. ones that use `<` and `>` around them). In the case that the pattern between the angle brackets resulted in no values, the processor would add an automatically generated value. From this version, this behaviour is removed and if the pattern returns no values, no URIs will be generated.
+
 ## [0.3.4] - 2026-05-11
 
 ## Fixed

--- a/src/rdf_mapper/lib/template_support.py
+++ b/src/rdf_mapper/lib/template_support.py
@@ -160,9 +160,6 @@ def uri_expand(pattern: str, namespaces: Mapping[str,str], state: TemplateState)
             for uri_value in uri_values:
                 urirefs.append(_expand_curi(str(uri_value), namespaces))
 
-        if len(urirefs) == 0:
-            urirefs.append(f"{state.get('$datasetBase')}/data/{state.get('$resourceID')}")
-
         return list(map(lambda uriref: _make_full_iri(uriref, state), urirefs))
     else:
         # Simple string, create as def in dataset namespace

--- a/test/test_template_support.py
+++ b/test/test_template_support.py
@@ -71,6 +71,9 @@ class TestTemplateSupport(unittest.TestCase):
         self.assertEqual(
             uri_expand("<http://example.com/{x|hash()}/baz>", spec.namespaces, state),
             ["http://example.com/1FNCFDFA7S7TNIAT1NA7UF2RO9QTL2HJ/baz"])
+        self.assertEqual(
+            uri_expand("<{missing}>", spec.namespaces, state),
+            [])
 
     def test_value_expand(self) -> None:
         spec = self._dummy_spec


### PR DESCRIPTION
Fixes #75 
When a property value template that is URI expanded, if the unexpanded result is an empty list, do not add an auto-generated ID and instead return an empty list of expaneded URIs.
This is a change to the behaviour of the rdf-mapper which is a hangover from the agrimetrics mapper days and which makes it impossible to use such property templates to conditionally generate URIs.